### PR TITLE
Achievements can contain several parameters when sent.

### DIFF
--- a/examples/send_achieve_param/master.asl
+++ b/examples/send_achieve_param/master.asl
@@ -4,4 +4,6 @@
  	 ?slave1(X);
     .print("Sending message to slave1");
     .send(X, achieve, say("Hello BDI"));
-    .print("Message sent").
+    .print("Message 1 sent");
+    .send(X, achieve, sayall("Hello", "BDI"));
+    .print("Message 2 sent").

--- a/examples/send_achieve_param/slave.asl
+++ b/examples/send_achieve_param/slave.asl
@@ -1,1 +1,3 @@
 +!say(M) <- .print("master has said: ", M).
+
++!sayall(M,N) <- .print("master has said two things: ", M, N).

--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -315,7 +315,11 @@ def parse_literal(msg):
                 return tuple(recursion(i) for i in arg)
             return arg
 
-        new_args = (recursion(args),)
+        t_args = recursion(args)
+        if isinstance(t_args, tuple):
+            new_args = t_args
+        else:
+            new_args = (t_args,)
 
     else:
         new_args = ""


### PR DESCRIPTION
Sending achieve messages with several parameters in the literal was failing. This commit patches the bdi.py/parse_literal function to handle that case. A tests is added in examples/send_achieve_param (master.asl and slave.asl).

This particular test runs well, but I did not manage to run the full test suite because of some deprecations in the current versions of the test tools.