### PR TITLE
fix(bdi): read ilf_type metadata with safe accessor

### DIFF
--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -209,7 +209,7 @@ class BDIAgent(Agent):
             if self.agent.bdi_enabled:
                 msg = await self.receive(timeout=0)
                 if msg:
-                    mdata = msg.metadata
+                    mdata = msg._metadata
                     ilf_type = mdata["ilf_type"]
                     if ilf_type == "tell":
                         goal_type = asp.GoalType.belief

--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -209,7 +209,7 @@ class BDIAgent(Agent):
             if self.agent.bdi_enabled:
                 msg = await self.receive(timeout=0)
                 if msg:
-                    mdata = msg._metadata
+                    mdata = msg.get_metadata()
                     ilf_type = mdata["ilf_type"]
                     if ilf_type == "tell":
                         goal_type = asp.GoalType.belief

--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -271,7 +271,6 @@ class BDIAgent(Agent):
                     else:
                         # Sends a literal
                         functor, args = parse_literal(msg.body)
-
                         message = asp.Literal(functor, args)
 
                     message = asp.freeze(message, intention.scope, {})
@@ -299,35 +298,55 @@ class BDIAgent(Agent):
                 await asyncio.sleep(0.1)
 
 
+def _split_args(s):
+    """Split a comma-separated args string respecting nested parentheses."""
+    args = []
+    depth = 0
+    current = []
+    for c in s:
+        if c == '(':
+            depth += 1
+        elif c == ')':
+            depth -= 1
+        if c == ',' and depth == 0:
+            args.append(''.join(current).strip())
+            current = []
+        else:
+            current.append(c)
+    if current:
+        args.append(''.join(current).strip())
+    return [a for a in args if a]
+
+
+def _parse_arg(s):
+    """Convert a single serialized argument to the appropriate Python/agentspeak type."""
+    s = s.strip()
+    if not s:
+        return None
+    # Variable
+    if re.search("^_X_*", s):
+        return asp.Var()
+    # Quoted string → Python str
+    if s.startswith('"') and s.endswith('"'):
+        return s[1:-1]
+    # Number or other Python literal
+    try:
+        return literal_eval(s)
+    except Exception:
+        pass
+    # Unquoted → atom (agentspeak Literal)
+    return asp.Literal(s)
+
+
 def parse_literal(msg):
     functor = msg.split("(")[0]
-
     if "(" in msg:
-        args = msg.split("(")[1]
-        args = args.split(")")[0]
-
-        x = re.search("^_X_*", args)
-
-        if x is not None:
-            args = asp.Var()
+        args_str = msg.split("(", 1)[1].rsplit(")", 1)[0]
+        parsed = [_parse_arg(a) for a in _split_args(args_str)]
+        if len(parsed) == 1:
+            new_args = (parsed[0],)
         else:
-            try:
-                args = literal_eval(args)
-            except:
-                # MRP: treat as atom
-                args = args.strip()
-
-        def recursion(arg):
-            if isinstance(arg, list):
-                return (tuple(arg),)
-            if isinstance(arg, tuple) and len(arg) > 1:
-                return arg
-            if isinstance(arg, str) or not hasattr(arg, '__iter__'):
-                return (arg,)
-            return arg
-
-        new_args = recursion(args)
-
+            new_args = tuple(parsed)
     else:
         new_args = ""
     return functor, new_args

--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -209,8 +209,7 @@ class BDIAgent(Agent):
             if self.agent.bdi_enabled:
                 msg = await self.receive(timeout=0)
                 if msg:
-                    mdata = msg.get_metadata()
-                    ilf_type = mdata["ilf_type"]
+                    ilf_type = msg.get_metadata("ilf_type")
                     if ilf_type == "tell":
                         goal_type = asp.GoalType.belief
                         trigger = asp.Trigger.addition

--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -68,9 +68,11 @@ class BDIAgent(Agent):
     def _load_asl(self):
         self.pause_bdi()
         try:
+            #MRP: to use the name of the agent in .my_name internal funcion of agentspeak
             with open(self.asl_file) as source:
-                self.bdi_agent = self.bdi_env.build_agent(source, self.bdi_actions)
+                self.bdi_agent = self.bdi_env.build_agent(source, self.bdi_actions, name=str(self.jid).split('@')[0])
             self.bdi_agent.name = self.jid
+            self.bdi_agent.spade_agent = self
             self.resume_bdi()
         except FileNotFoundError:
             logger.info(

--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -168,9 +168,12 @@ class BDIAgent(Agent):
 
         @staticmethod
         def _remove_source(belief, source):
-            if ")[source" in belief and not source:
-                belief = belief.split("[")[0].replace('"', "")
-            return belief
+            if "[source" in belief and not source:
+                if ")[source" in belief:
+                    belief = belief.split(")[source")[0] + ")"
+                else:
+                    belief = belief.split("[source")[0]
+            return belief.replace('"', "")
 
         def get_belief_value(self, key: str):
             """Get an agent's existing value or values of the <key> belief. The first belief matching
@@ -308,14 +311,22 @@ def parse_literal(msg):
         if x is not None:
             args = asp.Var()
         else:
-            args = literal_eval(args)
+            try:
+                args = literal_eval(args)
+            except:
+                # MRP: treat as atom
+                args = args.strip()
 
         def recursion(arg):
             if isinstance(arg, list):
-                return tuple(recursion(i) for i in arg)
+                return (tuple(arg),)
+            if isinstance(arg, tuple) and len(arg) > 1:
+                return arg
+            if isinstance(arg, str) or not hasattr(arg, '__iter__'):
+                return (arg,)
             return arg
 
-        new_args = (recursion(args),)
+        new_args = recursion(args)
 
     else:
         new_args = ""

--- a/spade_bdi/bdi.py
+++ b/spade_bdi/bdi.py
@@ -68,11 +68,9 @@ class BDIAgent(Agent):
     def _load_asl(self):
         self.pause_bdi()
         try:
-            #MRP: to use the name of the agent in .my_name internal funcion of agentspeak
             with open(self.asl_file) as source:
                 self.bdi_agent = self.bdi_env.build_agent(source, self.bdi_actions, name=str(self.jid).split('@')[0])
             self.bdi_agent.name = self.jid
-            self.bdi_agent.spade_agent = self
             self.resume_bdi()
         except FileNotFoundError:
             logger.info(


### PR DESCRIPTION
- Uses `msg.get_metadata("ilf_type")` instead of indexing metadata mapping directly.
- Avoids metadata access errors and keeps message trigger handling stable.